### PR TITLE
paramter error fixed.

### DIFF
--- a/run_new.py
+++ b/run_new.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
                         default=False, action=argparse.BooleanOptionalAction,
                         help="new save or do not")
     args = parser.parse_args()
-    cd_obj = None
+    cd_obj = [{'id':'', 'pw':''}]
     cd_len = 1
     headless = args.headless
     newsave = args.newsave


### PR DESCRIPTION
parameter로 실행시에 
Traceback (most recent call last):
  File "/home/ubuntu/naver-paper/run_new.py", line 180, in <module>
    cd_obj[0]["id"] = args.id
TypeError: 'NoneType' object is not subscriptable

오류가 발생합니다.

157라인에
cd_obj = None
대신에
cd_obj = [{'id':'', 'pw':''}]
로 선언했습니다.
