### PR TITLE
THIRD_PARTY_NOTICES.chromedriver 에러 해결

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ selenium==4.16.0
 requests==2.32.0
 soupsieve==2.5
 urllib3==2.2.2
-webdriver-manager==4.0.1
+webdriver-manager==4.0.2


### PR DESCRIPTION
기존 코드로 github actions에서 실행했을때 THIRD_PARTY_NOTICES.chromedriver 에러가 발생하는 문제를 해결합니다.

참고
- https://stackoverflow.com/questions/78806812/third-party-notices-chromedriver-exec-format-error-undetected-chromedriver
- https://github.com/SergeyPirogov/webdriver_manager/commit/3280b007d7e508b8190f1cb717a92229e53742f7